### PR TITLE
exclude cf_script from rewrite rules

### DIFF
--- a/templates/urlrewrite.xml
+++ b/templates/urlrewrite.xml
@@ -28,7 +28,7 @@ If you do not use Tuckey or Commandbox, this file can be safely deleted.
 <urlrewrite>
   <rule enabled="true">
     <name>CFWheels pretty URLs</name>
-    <condition type="request-uri" operator="notequal">^/(flex2gateway|jrunscripts|cfide|cfformgateway|cffileservlet|lucee|files|images|javascripts|miscellaneous|stylesheets|wheels/public/assets|robots.txt|favicon.ico|sitemap.xml|rewrite.cfm)</condition>
+    <condition type="request-uri" operator="notequal">^/(cf_script|flex2gateway|jrunscripts|cfide|cfformgateway|cffileservlet|lucee|files|images|javascripts|miscellaneous|stylesheets|wheels/public/assets|robots.txt|favicon.ico|sitemap.xml|rewrite.cfm)</condition>
     <from>^/(.*)$</from>
     <to type="passthrough">/rewrite.cfm/$1</to>
   </rule>


### PR DESCRIPTION
Unless we exclude cf_script, ACF 2018 CFIDE/Administrator will fail to work. More detail can be found in this thread.

https://groups.google.com/forum/#!topic/cfwheels/C_HMnGjft0E