### PR TITLE
Update NEW command and added create app command.

### DIFF
--- a/commands/wheels/create/app.cfc
+++ b/commands/wheels/create/app.cfc
@@ -19,7 +19,7 @@
  * The skeleton parameter can also be any valid Endpoint ID, which includes a Git repo or HTTP URL pointing to a package.
  * .
  * {code:bash}
- * coldbox create app skeleton=http://site.com/myCustomAppTemplate.zip
+ * wheels create app skeleton=http://site.com/myCustomAppTemplate.zip
  * {code}
  *
  **/
@@ -48,23 +48,13 @@ component {
 	 * @skeleton.optionsUDF skeletonComplete
 	 * @directory The directory to create the app in
 	 * @init "init" the directory as a package if it isn't already
-	 * @wizard Run the ColdBox Creation wizard
-	 * @initWizard Run the init creation package wizard
 	 **/
 	function run(
 		name               = "My CFWheels App",
 		skeleton           = "Base",
 		directory          = getCWD(),
-		boolean init       = false,
-		boolean wizard     = false,
-		boolean initWizard = false
+		boolean init       = false
 	){
-		// Check for wizard argument
-		if ( arguments.wizard ) {
-			runCommand( "wheels create app-wizard" );
-			return;
-		}
-
 		// This will make the directory canonical and absolute
 		arguments.directory = resolvePath( arguments.directory );
 

--- a/commands/wheels/create/app.cfc
+++ b/commands/wheels/create/app.cfc
@@ -1,0 +1,138 @@
+/**
+ *  Create a blank CFWheels app from one of our app skeletons or a skeleton using a valid Endpoint ID which can come from .
+ *  ForgeBox, HTTP/S, git, github, etc.
+ *  By default it will create the application in your current directory.
+ * .
+ * {code:bash}
+ * wheels create app myApp
+ * {code}
+ * .
+ *  Here are the basic skeletons that are available for you that come from ForgeBox
+ *  - Base (default)
+ *  - HelloWorld
+ *  - HelloDynamic
+ * .
+ * {code:bash}
+ * wheels create app skeleton=base
+ * {code}
+ * .
+ * The skeleton parameter can also be any valid Endpoint ID, which includes a Git repo or HTTP URL pointing to a package.
+ * .
+ * {code:bash}
+ * coldbox create app skeleton=http://site.com/myCustomAppTemplate.zip
+ * {code}
+ *
+ **/
+component {
+
+	// DI
+	property name="packageService" inject="PackageService";
+
+	/**
+	 * Constructor
+	 */
+	function init(){
+		// Map these shortcut names to the actual ForgeBox slugs
+		variables.templateMap = {
+			"Base"           : "cfwheels-template-base",
+			"HelloWorld"     : "cfwheels-template-helloworld",
+			"HelloDynamic"   : "cfwheels-template-hellodynamic",
+		};
+
+		return this;
+	}
+
+	/**
+	 * @name The name of the app you want to create
+	 * @skeleton The name of the app skeleton to generate (or an endpoint ID like a forgebox slug)
+	 * @skeleton.optionsUDF skeletonComplete
+	 * @directory The directory to create the app in
+	 * @init "init" the directory as a package if it isn't already
+	 * @wizard Run the ColdBox Creation wizard
+	 * @initWizard Run the init creation package wizard
+	 **/
+	function run(
+		name               = "My CFWheels App",
+		skeleton           = "Base",
+		directory          = getCWD(),
+		boolean init       = false,
+		boolean wizard     = false,
+		boolean initWizard = false
+	){
+		// Check for wizard argument
+		if ( arguments.wizard ) {
+			runCommand( "wheels create app-wizard" );
+			return;
+		}
+
+		// This will make the directory canonical and absolute
+		arguments.directory = resolvePath( arguments.directory );
+
+		// Validate directory, if it doesn't exist, create it.
+		if ( !directoryExists( arguments.directory ) ) {
+			directoryCreate( arguments.directory );
+		}
+
+		// If the skeleton is one of our "shortcut" names
+		if ( variables.templateMap.keyExists( arguments.skeleton ) ) {
+			// Replace it with the actual ForgeBox slug name.
+			arguments.skeleton = variables.templateMap[ arguments.skeleton ];
+		}
+
+		// Install the skeleton
+		packageService.installPackage(
+			ID                      = arguments.skeleton,
+			directory               = arguments.directory,
+			save                    = false,
+			saveDev                 = false,
+			production              = false,
+			currentWorkingDirectory = arguments.directory
+		);
+
+		// Check for the @appname@ in .project files
+		if ( fileExists( "#arguments.directory#/.project" ) ) {
+			var sProject = fileRead( "#arguments.directory#/.project" );
+			sProject     = replaceNoCase(
+				sProject,
+				"@appName@",
+				arguments.name,
+				"all"
+			);
+			file action="write" file="#arguments.directory#/.project" mode="755" output="#sProject#";
+		}
+
+		// Init, if not a package as a Box Package
+		if ( arguments.init && !packageService.isPackage( arguments.directory ) ) {
+			var originalPath = getCWD();
+			// init must be run from CWD
+			shell.cd( arguments.directory );
+			command( "init" )
+				.params(
+					name   = arguments.name,
+					slug   = replace( arguments.name, " ", "", "all" ),
+					wizard = arguments.initWizard
+				)
+				.run();
+			shell.cd( originalPath );
+		}
+
+		// Prepare defaults on box.json so we remove template based ones
+		command( "package set" )
+			.params(
+				name     = arguments.name,
+				slug     = variables.formatterUtil.slugify( arguments.name ),
+				version  = "1.0.0",
+				location = "",
+				scripts  = "{}"
+			)
+			.run();
+	}
+
+	/**
+	 * Returns an array of cfwheels skeletons available
+	 */
+	function skeletonComplete(){
+		return variables.templateMap.keyList().listToArray();
+	}
+
+}

--- a/commands/wheels/create/app.cfc
+++ b/commands/wheels/create/app.cfc
@@ -116,6 +116,9 @@ component {
 			shell.cd( originalPath );
 		}
 
+		// Run postInstallAll script
+		command( "package run-script postInstallAll" ).run();
+
 		// Prepare defaults on box.json so we remove template based ones
 		command( "package set" )
 			.params(

--- a/commands/wheels/create/app.cfc
+++ b/commands/wheels/create/app.cfc
@@ -117,7 +117,11 @@ component {
 		}
 
 		// Run postInstallAll script
-		command( "package run-script postInstallAll" ).run();
+		command( "package run-script" )
+			.params(
+				scriptname = "postInstallAll"
+			)
+			.run();
 
 		// Prepare defaults on box.json so we remove template based ones
 		command( "package set" )

--- a/commands/wheels/create/app.cfc
+++ b/commands/wheels/create/app.cfc
@@ -1,5 +1,5 @@
 /**
- *  Create a blank CFWheels app from one of our app skeletons or a skeleton using a valid Endpoint ID which can come from .
+ *  Create a blank CFWheels app from one of our app templates or a template using a valid Endpoint ID which can come from .
  *  ForgeBox, HTTP/S, git, github, etc.
  *  By default it will create the application in your current directory.
  * .
@@ -7,19 +7,19 @@
  * wheels create app myApp
  * {code}
  * .
- *  Here are the basic skeletons that are available for you that come from ForgeBox
+ *  Here are the basic templates that are available for you that come from ForgeBox
  *  - Base (default)
  *  - HelloWorld
  *  - HelloDynamic
  * .
  * {code:bash}
- * wheels create app skeleton=base
+ * wheels create app template=base
  * {code}
  * .
- * The skeleton parameter can also be any valid Endpoint ID, which includes a Git repo or HTTP URL pointing to a package.
+ * The template parameter can also be any valid Endpoint ID, which includes a Git repo or HTTP URL pointing to a package.
  * .
  * {code:bash}
- * wheels create app skeleton=http://site.com/myCustomAppTemplate.zip
+ * wheels create app template=http://site.com/myCustomAppTemplate.zip
  * {code}
  *
  **/
@@ -44,14 +44,14 @@ component {
 
 	/**
 	 * @name The name of the app you want to create
-	 * @skeleton The name of the app skeleton to generate (or an endpoint ID like a forgebox slug)
-	 * @skeleton.optionsUDF skeletonComplete
+	 * @template The name of the app template to generate (or an endpoint ID like a forgebox slug)
+	 * @template.optionsUDF templateComplete
 	 * @directory The directory to create the app in
 	 * @init "init" the directory as a package if it isn't already
 	 **/
 	function run(
 		name               = "My CFWheels App",
-		skeleton           = "Base",
+		template           = "Base",
 		directory          = getCWD(),
 		boolean init       = false
 	){
@@ -63,15 +63,15 @@ component {
 			directoryCreate( arguments.directory );
 		}
 
-		// If the skeleton is one of our "shortcut" names
-		if ( variables.templateMap.keyExists( arguments.skeleton ) ) {
+		// If the template is one of our "shortcut" names
+		if ( variables.templateMap.keyExists( arguments.template ) ) {
 			// Replace it with the actual ForgeBox slug name.
-			arguments.skeleton = variables.templateMap[ arguments.skeleton ];
+			arguments.template = variables.templateMap[ arguments.template ];
 		}
 
-		// Install the skeleton
+		// Install the template
 		packageService.installPackage(
-			ID                      = arguments.skeleton,
+			ID                      = arguments.template,
 			directory               = arguments.directory,
 			save                    = false,
 			saveDev                 = false,
@@ -126,9 +126,9 @@ component {
 	}
 
 	/**
-	 * Returns an array of cfwheels skeletons available
+	 * Returns an array of cfwheels templates available
 	 */
-	function skeletonComplete(){
+	function templateComplete(){
 		return variables.templateMap.keyList().listToArray();
 	}
 

--- a/commands/wheels/new.cfc
+++ b/commands/wheels/new.cfc
@@ -177,12 +177,7 @@ component extends="base"  {
 			createH2Embedded=false;
 		}
 
- 		//---------------- This is just an idea at the moment really.
-  		print.greenBoldLine( "========= Twitter Bootstrap ======================" ).toConsole();
 		var useBootstrap3=false;
-	    if(confirm("Would you like us to setup some default Bootstrap3 settings? [y/n]")){
-	    	useBootstrap3 = true;
-	    }
 
 		print.line();
 		print.line();


### PR DESCRIPTION
This is a incremental update. I've got template based app creation working using:

`wheels create app template=Base`

I've got three templates posted to ForgBox and worked with Brad Wood to create a CFWheels Templates type in the list. I'm working on building a cfwheels-template-helloworld but having issues with the H2 driver and migrations. I'd really like to get that working with H2 so people don't have to rely on any other service. I'll see how that goes.

I also removed the bootstrap option from `wheels new` sense we can now create a template that has bootstrap, tailwind, or any other library baked in.