### PR TITLE
remove appconfig template reference

### DIFF
--- a/commands/wheels/generate/app-wizard.cfc
+++ b/commands/wheels/generate/app-wizard.cfc
@@ -32,7 +32,6 @@ component aliases="wheels g app-wizard, wheels new" extends="../base" {
 
   function run( ) {
     var appContent      = fileRead( helpers.getTemplate( '/ConfigAppContent.txt' ) );
-    var settingsContent = fileRead( helpers.getTemplate( '/ConfigSettingsContent.txt' ) );
     var routesContent   = fileRead( helpers.getTemplate( '/ConfigRoutes.txt' ) );
 
     // ---------------- Welcome


### PR DESCRIPTION
This removes a reference to a template file that was removed. This was reported by a user on the mailing list.